### PR TITLE
Dont run self-update twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 7.3
 
 before_script:
-  - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:


### PR DESCRIPTION
Travis already runs composer self-update by default, so no need to do it twice