### PR TITLE
Fix division by zero in array_split()

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ function array_split_filter(array $array, callable $callback)
  * @param array $array
  * @param int $numberOfPieces
  * @param bool $preserveKeys
+ * @throws \InvalidArgumentException
  * @return array
  */
 function array_split(array $array, $numberOfPieces = 2, $preserveKeys = false)

--- a/src/array_functions.php
+++ b/src/array_functions.php
@@ -111,11 +111,16 @@ function array_split_filter(array $array, callable $callback)
  * @param array $array
  * @param int   $numberOfPieces
  * @param bool  $preserveKeys
+ * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower then 1
  *
  * @return array
  */
 function array_split(array $array, $numberOfPieces = 2, $preserveKeys = false)
 {
+    if ($numberOfPieces <= 0) {
+        throw new \InvalidArgumentException('Number of pieces parameter expected to be greater than 0');
+    }
+
     if (count($array) === 0) {
         return [];
     }

--- a/src/array_functions.php
+++ b/src/array_functions.php
@@ -111,7 +111,7 @@ function array_split_filter(array $array, callable $callback)
  * @param array $array
  * @param int   $numberOfPieces
  * @param bool  $preserveKeys
- * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower then 1
+ * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower than 1
  *
  * @return array
  */

--- a/tests/ArraySplitTest.php
+++ b/tests/ArraySplitTest.php
@@ -16,6 +16,31 @@ class ArraySplitTest extends TestCase
     }
 
     /**
+     * @dataProvider argumentsProvider
+     * @test
+     */
+    public function it_throws_exception_when_second_parameter_is_lower_then_1($numberOfPieces, $mustThrow)
+    {
+        $exception = null;
+        try {
+            array_split([], $numberOfPieces);
+        } catch (\InvalidArgumentException $exception) {}
+
+        $this->assertSame($mustThrow, $exception instanceof \InvalidArgumentException);
+    }
+
+    public function argumentsProvider()
+    {
+        return [
+          [2 , false],
+          [1 , false],
+          [0 , true],
+          [-1 , true],
+          [-2 , true],
+        ];
+    }
+
+    /**
      * @test
      */
     public function it_splits_an_array_in_two_by_default()

--- a/tests/ArraySplitTest.php
+++ b/tests/ArraySplitTest.php
@@ -19,7 +19,7 @@ class ArraySplitTest extends TestCase
      * @dataProvider argumentsProvider
      * @test
      */
-    public function it_throws_exception_when_second_parameter_is_lower_then_1($numberOfPieces, $mustThrow)
+    public function it_throws_exception_when_second_parameter_is_lower_than_1($numberOfPieces, $mustThrow)
     {
         $exception = null;
         try {


### PR DESCRIPTION
Throws `\InvalidArgumentException` if the provided argument $numberOfPieces is lower than 1.

`array_chunk()` has similar behavior.