### PR TITLE
Refactor to include Arr class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,18 @@
         }
     ],
     "require": {
-        "php" : "^7.2"
+        "php": "^7.2"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^7.0"
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
-        "files": ["src/array_functions.php"]
+        "psr-4": {
+            "Spatie\\": "src/"
+        },
+        "files": [
+            "src/array_functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Spatie\Support;
+
+class Arr
+{
+    /**
+     * Get a random value from an array.
+     *
+     * @param array $array
+     * @param int   $numReq The amount of values to return
+     *
+     * @return mixed
+     */
+    public static function randValue(array $array, $numReq = 1)
+    {
+        if (!count($array)) {
+            return;
+        }
+
+        $keys = array_rand($array, $numReq);
+
+        if ($numReq === 1) {
+            return $array[$keys];
+        }
+
+        return array_intersect_key($array, array_flip($keys));
+    }
+
+    /**
+     * Get a random value from an array, with the ability to skew the results.
+     * Example: Arr::randWeighted(['foo' => 1, 'bar' => 2]) has a 66% chance of returning bar.
+     *
+     * @param array $array
+     *
+     * @return mixed
+     */
+    public static function randWeighted(array $array)
+    {
+        $options = [];
+
+        foreach ($array as $option => $weight) {
+            for ($i = 0; $i < $weight; ++$i) {
+                $options[] = $option;
+            }
+        }
+
+        return array_rand_value($options);
+    }
+
+    /**
+     * Determine if all given needles are present in the haystack.
+     *
+     * @param array|string $needles
+     * @param array        $haystack
+     *
+     * @return bool
+     */
+    public static function valuesInArray($needles, array $haystack)
+    {
+        if (!is_array($needles)) {
+            $needles = [$needles];
+        }
+
+        return count(array_intersect($needles, $haystack)) === count($needles);
+    }
+
+    /**
+     * Determine if all given needles are present in the haystack as array keys.
+     *
+     * @param array|string $needles
+     * @param array        $haystack
+     *
+     * @return bool
+     */
+    public static function keysExist($needles, array $haystack)
+    {
+        if (!is_array($needles)) {
+            return array_key_exists($needles, $haystack);
+        }
+
+        return values_in_array($needles, array_keys($haystack));
+    }
+
+    /**
+     * Returns an array with two elements.
+     *
+     * Iterates over each value in the array passing them to the callback function.
+     * If the callback function returns true, the current value from array is returned in the first
+     * element of result array. If not, it is return in the second element of result array.
+     *
+     * Array keys are preserved.
+     *
+     * @param array    $array
+     * @param callable $callback
+     *
+     * @return array
+     */
+    public static function splitFilter(array $array, callable $callback)
+    {
+        $passesFilter = array_filter($array, $callback);
+
+        $negatedCallback = static function ($item) use ($callback) {return !$callback($item);};
+
+        $doesNotPassFilter = array_filter($array, $negatedCallback);
+
+        return [$passesFilter, $doesNotPassFilter];
+    }
+
+    /**
+     * Split an array in the given amount of pieces.
+     *
+     * @param array $array
+     * @param int   $numberOfPieces
+     * @param bool  $preserveKeys
+     * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower than 1
+     *
+     * @return array
+     */
+    public static function split(array $array, $numberOfPieces = 2, $preserveKeys = false)
+    {
+        if ($numberOfPieces <= 0) {
+            throw new \InvalidArgumentException('Number of pieces parameter expected to be greater than 0');
+        }
+
+        if (count($array) === 0) {
+            return [];
+        }
+
+        $splitSize = ceil(count($array) / $numberOfPieces);
+
+        return array_chunk($array, $splitSize, $preserveKeys);
+    }
+
+    /**
+     * Returns an array with the unique values from all the given arrays.
+     *
+     * @param \array[] $arrays
+     *
+     * @return array
+     */
+    public static function mergeValues(array...$arrays)
+    {
+        $allValues = array_reduce($arrays, static function ($carry, $array) {
+            return array_merge($carry, $array);
+        }, []);
+
+        return array_values(array_unique($allValues));
+    }
+
+    /**
+     * Flatten an array of arrays. The `$levels` parameter specifies how deep you want to
+     * recurse in the array. If `$levels` is -1, the function will recurse infinitely.
+     *
+     * @param array $array
+     * @param int   $levels
+     *
+     * @return array
+     */
+    public static function flatten(array $array, $levels = -1)
+    {
+        if ($levels === 0) {
+            return $array;
+        }
+
+        $flattened = [];
+
+        if ($levels !== -1) {
+            --$levels;
+        }
+
+        foreach ($array as $element) {
+            $flattened[] = is_array($element) ? array_flatten($element, $levels) : [$element];
+        }
+
+        return array_merge([], ...$flattened);
+    }
+}

--- a/src/array_functions.php
+++ b/src/array_functions.php
@@ -2,174 +2,132 @@
 
 namespace Spatie;
 
-/**
- * Get a random value from an array.
- *
- * @param array $array
- * @param int   $numReq The amount of values to return
- *
- * @return mixed
- */
-function array_rand_value(array $array, $numReq = 1)
-{
-    if (!count($array)) {
-        return;
+use Spatie\Support\Arr;
+
+if (!function_exists('array_rand_value')) {
+    /**
+     * Get a random value from an array.
+     *
+     * @param array $array
+     * @param int   $numReq The amount of values to return
+     *
+     * @return mixed
+     */
+    function array_rand_value(array $array, $numReq = 1)
+    {
+        return Arr::randValue($array, $numReq);
     }
-
-    $keys = array_rand($array, $numReq);
-
-    if ($numReq === 1) {
-        return $array[$keys];
-    }
-
-    return array_intersect_key($array, array_flip($keys));
 }
 
-/**
- * Get a random value from an array, with the ability to skew the results.
- * Example: array_rand_weighted(['foo' => 1, 'bar' => 2]) has a 66% chance of returning bar.
- *
- * @param array $array
- *
- * @return mixed
- */
-function array_rand_weighted(array $array)
-{
-    $options = [];
-
-    foreach ($array as $option => $weight) {
-        for ($i = 0; $i < $weight; ++$i) {
-            $options[] = $option;
-        }
+if (!function_exists('array_rand_weighted')) {
+    /**
+     * Get a random value from an array, with the ability to skew the results.
+     * Example: array_rand_weighted(['foo' => 1, 'bar' => 2]) has a 66% chance of returning bar.
+     *
+     * @param array $array
+     *
+     * @return mixed
+     */
+    function array_rand_weighted(array $array)
+    {
+        return Arr::randWeighted($array);
     }
-
-    return array_rand_value($options);
 }
 
-/**
- * Determine if all given needles are present in the haystack.
- *
- * @param array|string $needles
- * @param array        $haystack
- *
- * @return bool
- */
-function values_in_array($needles, array $haystack)
-{
-    if (!is_array($needles)) {
-        $needles = [$needles];
+if (!function_exists('values_in_array')) {
+    /**
+     * Determine if all given needles are present in the haystack.
+     *
+     * @param array|string $needles
+     * @param array        $haystack
+     *
+     * @return bool
+     */
+    function values_in_array($needles, array $haystack)
+    {
+        return Arr::valuesInArray($needles, $haystack);
     }
-
-    return count(array_intersect($needles, $haystack)) === count($needles);
 }
 
-/**
- * Determine if all given needles are present in the haystack as array keys.
- *
- * @param array|string $needles
- * @param array        $haystack
- *
- * @return bool
- */
-function array_keys_exist($needles, array $haystack)
-{
-    if (!is_array($needles)) {
-        return array_key_exists($needles, $haystack);
+if (!function_exists('array_keys_exist')) {
+    /**
+     * Determine if all given needles are present in the haystack as array keys.
+     *
+     * @param array|string $needles
+     * @param array        $haystack
+     *
+     * @return bool
+     */
+    function array_keys_exist($needles, array $haystack)
+    {
+        return Arr::keysExist($needles, $haystack);
     }
-
-    return values_in_array($needles, array_keys($haystack));
 }
 
-/**
- * Returns an array with two elements.
- *
- * Iterates over each value in the array passing them to the callback function.
- * If the callback function returns true, the current value from array is returned in the first
- * element of result array. If not, it is return in the second element of result array.
- *
- * Array keys are preserved.
- *
- * @param array    $array
- * @param callable $callback
- *
- * @return array
- */
-function array_split_filter(array $array, callable $callback)
-{
-    $passesFilter = array_filter($array, $callback);
-
-    $negatedCallback = static function ($item) use ($callback) { return !$callback($item); };
-
-    $doesNotPassFilter = array_filter($array, $negatedCallback);
-
-    return [$passesFilter, $doesNotPassFilter];
+if (!function_exists('array_split_filter')) {
+    /**
+     * Returns an array with two elements.
+     *
+     * Iterates over each value in the array passing them to the callback function.
+     * If the callback function returns true, the current value from array is returned in the first
+     * element of result array. If not, it is return in the second element of result array.
+     *
+     * Array keys are preserved.
+     *
+     * @param array    $array
+     * @param callable $callback
+     *
+     * @return array
+     */
+    function array_split_filter(array $array, callable $callback)
+    {
+        return Arr::splitFilter($array, $callback);
+    }
 }
 
-/**
- * Split an array in the given amount of pieces.
- *
- * @param array $array
- * @param int   $numberOfPieces
- * @param bool  $preserveKeys
- * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower than 1
- *
- * @return array
- */
-function array_split(array $array, $numberOfPieces = 2, $preserveKeys = false)
-{
-    if ($numberOfPieces <= 0) {
-        throw new \InvalidArgumentException('Number of pieces parameter expected to be greater than 0');
+if (!function_exists('array_split')) {
+    /**
+     * Split an array in the given amount of pieces.
+     *
+     * @param array $array
+     * @param int   $numberOfPieces
+     * @param bool  $preserveKeys
+     * @throws \InvalidArgumentException if the provided argument $numberOfPieces is lower than 1
+     *
+     * @return array
+     */
+    function array_split(array $array, $numberOfPieces = 2, $preserveKeys = false)
+    {
+        return Arr::split($array, $numberOfPieces, $preserveKeys);
     }
-
-    if (count($array) === 0) {
-        return [];
-    }
-
-    $splitSize = ceil(count($array) / $numberOfPieces);
-
-    return array_chunk($array, $splitSize, $preserveKeys);
 }
 
-/**
- * Returns an array with the unique values from all the given arrays.
- *
- * @param \array[] $arrays
- *
- * @return array
- */
-function array_merge_values(array ...$arrays)
-{
-    $allValues = array_reduce($arrays, static function ($carry, $array) {
-         return array_merge($carry, $array);
-    }, []);
-
-    return array_values(array_unique($allValues));
+if (!function_exists('array_merge_values')) {
+    /**
+     * Returns an array with the unique values from all the given arrays.
+     *
+     * @param \array[] $arrays
+     *
+     * @return array
+     */
+    function array_merge_values(array...$arrays)
+    {
+        return Arr::mergeValues($arrays);
+    }
 }
 
-/**
- * Flatten an array of arrays. The `$levels` parameter specifies how deep you want to
- * recurse in the array. If `$levels` is -1, the function will recurse infinitely.
- *
- * @param array $array
- * @param int   $levels
- *
- * @return array
- */
-function array_flatten(array $array, $levels = -1)
-{
-    if ($levels === 0) {
-        return $array;
+if (!function_exists('array_flatten')) {
+    /**
+     * Flatten an array of arrays. The `$levels` parameter specifies how deep you want to
+     * recurse in the array. If `$levels` is -1, the function will recurse infinitely.
+     *
+     * @param array $array
+     * @param int   $levels
+     *
+     * @return array
+     */
+    function array_flatten(array $array, $levels = -1)
+    {
+        return Arr::flatten($array, $levels);
     }
-
-    $flattened = [];
-
-    if ($levels !== -1) {
-        --$levels;
-    }
-
-    foreach ($array as $element) {
-        $flattened[] = is_array($element) ? array_flatten($element, $levels) : [$element];
-    }
-
-    return array_merge([], ...$flattened);
 }


### PR DESCRIPTION
Move each function definition to an Arr class as a static function. Then make each global function use the class function similar to the way Laravel does with it's internal Arr and Str classes. Check that each function does not exist before defining it.

Some people prefer to use Arr::flattern instead of array_flattern as finding the class definition is easier than a global function definition.