### PR TITLE
Optimize array_rand_weighted

### DIFF
--- a/src/array_functions.php
+++ b/src/array_functions.php
@@ -35,15 +35,21 @@ function array_rand_value(array $array, $numReq = 1)
  */
 function array_rand_weighted(array $array)
 {
-    $options = [];
+    $array = array_filter($array, function ($item) {
+        return $item >= 1;
+    });
 
-    foreach ($array as $option => $weight) {
-        for ($i = 0; $i < $weight; ++$i) {
-            $options[] = $option;
-        }
+    if (!count($array)) {
+        return;
     }
+    $totalWeight = array_sum($array);
 
-    return array_rand_value($options);
+    foreach ($array as $value => $weight) {
+        if (rand(1, $totalWeight) <= $weight) {
+            return $value;
+        }
+        $totalWeight -= $weight;
+    }
 }
 
 /**


### PR DESCRIPTION
I tested the performance of the new(array_rand_weighted_v2) and old(array_rand_weighted) functions, the result are as follows:

- GROUP 1: time usage

**array_rand_weighted**
|size|times|time usage (sec)|
|:-|:-|:-|
|10|10000|0.021669864654541|
|100|10000|0.12856888771057|
|1000|10000|1.2416679859161|
|10000|10000|21.270864009857|

**array_rand_weighted_v2**
|size|times|time usage (sec)|
|:-|:-|:-|
|10|10000|0.0097980499267578|
|100|10000|0.076462984085083|
|1000|10000|0.74438810348511|
|10000|10000|7.601450920105|

- GROUP 2: memory usage

**array_rand_weighted**
|size|times|memory usage (byte)|
|:-|:-|:-|
|10|10000|2097152|
|100|10000|2097152|
|1000|10000|2097152|
|10000|10000|6295552|
|50000|10000|23076864|

**array_rand_weighted_v2**
|size|times|memory usage (byte)|
|:-|:-|:-|
|10|10000|2097152|
|100|10000|2097152|
|1000|10000|2097152|
|10000|10000|4194304|
|50000|10000|8396800|

The benchmark code are here: [gist link](https://gist.github.com/Littlesqx/0dc525a3fcb34c43f774c46b5ea632bf)